### PR TITLE
Make gem compatible with Rails 5.1

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -6,7 +6,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
   VERSION = '0.9.1'.freeze
   # Rails 3.1 and beyond defines the constant elsewhere
   unless defined?(ENV_SESSION_OPTIONS_KEY)
-    if Rack.release.split('.').first.to_i > 1
+    if Rack.const_defined?(:RACK_SESSION_OPTIONS)
       ENV_SESSION_OPTIONS_KEY = Rack::RACK_SESSION_OPTIONS
     else
       ENV_SESSION_OPTIONS_KEY = Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY

--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
                     .match(/^  VERSION = '(.*)'/)[1]
 
   gem.add_runtime_dependency 'redis', '~> 3'
-  gem.add_runtime_dependency 'actionpack', '>= 3', '< 5.1'
+  gem.add_runtime_dependency 'actionpack', '>= 3', '< 5.2'
 
   gem.add_development_dependency 'fakeredis', '~> 0.5'
   gem.add_development_dependency 'rake', '~> 11'


### PR DESCRIPTION
**Why**: To allow apps that use this gem to update to Rails 5.1