### PR TITLE
Use AbstractSecureStore for security fix (redo)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,3 +23,4 @@ Redis Session Store authors
 - Anton Kolodii
 - Peter Karman
 - Zach Margolis
+- Zachary Belzer

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -3,7 +3,7 @@ require 'redis'
 # Redis session storage for Rails, and for Rails only. Derived from
 # the MemCacheStore code, simply dropping in Redis instead.
 class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
-  VERSION = '0.11.3'.freeze
+  VERSION = '0.11.4-18f'.freeze
   # Rails 3.1 and beyond defines the constant elsewhere
   unless defined?(ENV_SESSION_OPTIONS_KEY)
     ENV_SESSION_OPTIONS_KEY = if Rack.release.split('.').first.to_i > 1

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -2,7 +2,7 @@ require 'redis'
 
 # Redis session storage for Rails, and for Rails only. Derived from
 # the MemCacheStore code, simply dropping in Redis instead.
-class RedisSessionStore < ActionDispatch::Session::AbstractStore
+class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
   VERSION = '0.11.3'.freeze
   # Rails 3.1 and beyond defines the constant elsewhere
   unless defined?(ENV_SESSION_OPTIONS_KEY)

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -281,6 +281,13 @@ describe RedisSessionStore do
 
     let(:fake_key) { 'thisisarediskey' }
 
+    describe 'generate_sid' do
+      it 'generates a secure ID' do
+        sid = store.send(:generate_sid)
+        expect(sid).to be_a(Rack::Session::SessionId)
+      end
+    end
+
     it 'retrieves the prefixed key from redis' do
       redis = double('redis')
       allow(store).to receive(:redis).and_return(redis)

--- a/spec/support.rb
+++ b/spec/support.rb
@@ -7,11 +7,24 @@ unless defined?(Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY)
     end
   end
 end
+unless defined?(Rack::Session::SessionId)
+  module Rack
+    module Session
+      class SessionId
+        attr_reader :public_id
 
-unless defined?(ActionDispatch::Session::AbstractStore)
+        def initialize(public_id)
+          @public_id
+        end
+      end
+    end
+  end
+end
+
+unless defined?(ActionDispatch::Session::AbstractSecureStore)
   module ActionDispatch
     module Session
-      class AbstractStore
+      class AbstractSecureStore
         ENV_SESSION_OPTIONS_KEY = 'rack.session.options'.freeze
         DEFAULT_OPTIONS = {
           key: '_session_id',
@@ -33,7 +46,7 @@ unless defined?(ActionDispatch::Session::AbstractStore)
         private
 
         def generate_sid
-          rand(999..9999).to_s(16)
+          Rack::Session::SessionId.new(rand(999..9999).to_s(16))
         end
       end
     end


### PR DESCRIPTION
Redo of https://github.com/18F/redis-session-store/pull/4, port of https://github.com/roidrage/redis-session-store/pull/125 (I forgot to update the base branch before merging)

