### PR TITLE
Add option to use ConnectionPool

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -69,25 +69,25 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
   def session_exists?(env)
     value = current_session_id(env)
 
-    with_redis do |redis|
-      !!(
-        value && !value.empty? &&
-        key_exists?(value, redis: redis)
-      )
-    end
+    !!(
+      value && !value.empty? &&
+      key_exists?(value)
+    )
   rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
     on_redis_down.call(e, env, value) if on_redis_down
 
     true
   end
 
-  def key_exists?(value, redis:)
-    if redis.respond_to?(:exists?)
-      # added in redis gem v4.2
-      redis.exists?(prefixed(value))
-    else
-      # older method, will return an integer starting in redis gem v4.3
-      redis.exists(prefixed(value))
+  def key_exists?(value)
+    with_redis do |redis|
+      if redis.respond_to?(:exists?)
+        # added in redis gem v4.2
+        redis.exists?(prefixed(value))
+      else
+        # older method, will return an integer starting in redis gem v4.3
+        redis.exists(prefixed(value))
+      end
     end
   end
 

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -3,7 +3,7 @@ require 'redis'
 # Redis session storage for Rails, and for Rails only. Derived from
 # the MemCacheStore code, simply dropping in Redis instead.
 class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
-  VERSION = '0.11.5'.freeze
+  VERSION = '0.12-18f'.freeze
   # Rails 3.1 and beyond defines the constant elsewhere
   unless defined?(ENV_SESSION_OPTIONS_KEY)
     ENV_SESSION_OPTIONS_KEY = if Rack.release.split('.').first.to_i > 1

--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'actionpack', '>= 6', '< 8'
   gem.add_runtime_dependency 'redis', '>= 3', '< 6'
 
+  gem.add_development_dependency 'connection_pool', '~> 2'
   gem.add_development_dependency 'fakeredis', '~> 0.8'
   gem.add_development_dependency 'rake', '~> 13'
   gem.add_development_dependency 'rspec', '~> 3'


### PR DESCRIPTION
We should merge https://github.com/18F/redis-session-store/pull/7 first

This adds the option to pool Redis connections which helps us not spend time creating new connections to redis on every request