### PR TITLE
Significant re-write of internal functionality

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'redis'
 
 # Redis session storage for Rails, and for Rails only. Derived from

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -5,7 +5,7 @@ require 'redis'
 # Redis session storage for Rails, and for Rails only. Derived from
 # the MemCacheStore code, simply dropping in Redis instead.
 class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
-  VERSION = '0.12-18f'.freeze
+  VERSION = '1.0.0-18f'.freeze
 
   # ==== Options
   # * +:key+ - Same as with the other cookie stores, key name

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -79,8 +79,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
   def create_sid(req)
     sid = generate_sid
 
-    req.env['redis_session_store'] ||= {}
-    req.env['redis_session_store']['new_session'] = true
+    req.env['redis_session_store.new_session'] = true
     sid
   end
 
@@ -104,7 +103,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
     begin
       data ? decode(data) : nil
     rescue StandardError => e
-      delete_session_from_redis(redis_connection, sid, { drop: true })
+      delete_session_from_redis(redis_connection, sid, req, { drop: true })
       on_session_load_error.call(e, sid) if on_session_load_error
       nil
     end
@@ -127,7 +126,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
       ex: ttl(default_redis_ttl, options[:expire_after]),
     }
 
-    if req.env.dig('redis_session_store', 'new_session') == true
+    if req.env['redis_session_store.new_session'] == true
       set_options[:nx] = true
     end
 

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -81,6 +81,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
     generate_sid
   end
 
+  # @api public
   def find_session(req, sid)
     with_redis_connection(default_rescue_value: [nil, {}]) do |redis_connection|
       existing_session = load_session_from_redis(redis_connection, req, sid)
@@ -111,6 +112,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
     serializer.load(data)
   end
 
+  # @api public
   def write_session(req, sid, session_data, options = nil)
     return false unless sid
 
@@ -144,6 +146,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
     serializer.dump(session_data)
   end
 
+  # @api public
   def delete_session(req, sid, options)
     with_redis_connection do |redis_connection|
       delete_session_from_redis(redis_connection, sid, req, options)

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -122,8 +122,9 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
       key = prefixed(sid)
     end
     return false unless key
+
     set_options = {
-      ex: ttl(default_redis_ttl, options[:expire_after]),
+      ex: options[:expire_after] || default_redis_ttl
     }
 
     if req.env['redis_session_store.new_session'] == true
@@ -159,10 +160,6 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
     redis_connection.del(prefixed(sid))
 
     create_sid(req) unless options[:drop]
-  end
-
-  def ttl(ttl, expire_after)
-    expire_after || ttl
   end
 
   def determine_serializer(serializer)

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -127,7 +127,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
       ex: options[:expire_after] || default_redis_ttl
     }
 
-    if req.env['redis_session_store.new_session'] == true
+    if req.env['redis_session_store.new_session']
       set_options[:nx] = true
     end
 

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -68,8 +68,11 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
   end
 
   def prefixed(sid)
-    return nil unless sid && sid.private_id
-    "#{default_options[:key_prefix]}#{sid.private_id}"
+    return nil unless sid
+    private_id = sid.private_id
+    return nil unless private_id
+
+    "#{default_options[:key_prefix]}#{private_id}"
   end
 
   def prefixed_fallback(sid)

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -77,10 +77,8 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
   end
 
   def create_sid(req)
-    sid = generate_sid
-
     req.env['redis_session_store.new_session'] = true
-    sid
+    generate_sid
   end
 
   def find_session(req, sid)

--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
                     .match(/^  VERSION = '(.*)'/)[1]
 
   gem.add_runtime_dependency 'actionpack', '>= 6', '< 8'
-  gem.add_runtime_dependency 'redis', '>= 3', '< 6'
+  gem.add_runtime_dependency 'redis', '>= 4.3', '< 6'
 
   gem.add_development_dependency 'connection_pool', '~> 2'
   gem.add_development_dependency 'fakeredis', '~> 0.8'

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -245,7 +245,7 @@ describe RedisSessionStore do
 
     shared_examples_for 'serializer' do
       it 'encodes correctly' do
-        expect(redis).to receive(:set).with(session_id.private_id, expected_encoding, { ex: nil })
+        expect(redis).to receive(:set).with(session_id.private_id, expected_encoding)
         store.send(:write_session, env, session_id, session_data, options)
       end
 

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -302,7 +302,6 @@ describe RedisSessionStore do
 
       it 'returns an empty session' do
         expect(store.send(:find_session, ActionDispatch::TestRequest.create, fake_key).last).to eq({})
-
       end
 
       it 'destroys and drops the session' do

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'connection_pool'
+require 'rack/session/abstract/id'
 
 describe RedisSessionStore do
   subject(:store) { described_class.new(nil, options) }
@@ -169,128 +170,6 @@ describe RedisSessionStore do
     end
   end
 
-  describe 'rack 1.45 compatibility' do
-    # Rack 1.45 (which Rails 3.2.x depends on) uses the return value of
-    # set_session to set the cookie value.  See:
-    # https://github.com/rack/rack/blob/1.4.5/lib/rack/session/abstract/id.rb
-
-    let(:env)          { double('env') }
-    let(:session_id)   { 12_345 }
-    let(:session_data) { double('session_data') }
-    let(:options)      { { expire_after: 123 } }
-
-    context 'when successfully persisting the session' do
-      it 'returns the session id' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
-          .to eq(session_id)
-      end
-    end
-
-    context 'when unsuccessfully persisting the session' do
-      before do
-        allow(store).to receive(:single_redis).and_raise(Redis::CannotConnectError)
-      end
-
-      it 'returns false' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
-          .to eq(false)
-      end
-    end
-
-    context 'when no expire_after option is given' do
-      let(:options) { {} }
-
-      it 'sets the session value without expiry' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
-          .to eq(session_id)
-      end
-    end
-
-    context 'when redis is down' do
-      before do
-        allow(store).to receive(:single_redis).and_raise(Redis::CannotConnectError)
-        store.on_redis_down = ->(*_a) { @redis_down_handled = true }
-      end
-
-      it 'returns false' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
-          .to eq(false)
-      end
-
-      it 'calls the on_redis_down handler' do
-        store.send(:set_session, env, session_id, session_data, options)
-        expect(@redis_down_handled).to eq(true)
-      end
-
-      context 'when :on_redis_down re-raises' do
-        before { store.on_redis_down = ->(e, *) { raise e } }
-
-        it 'explodes' do
-          expect do
-            store.send(:set_session, env, session_id, session_data, options)
-          end.to raise_error(Redis::CannotConnectError)
-        end
-      end
-    end
-  end
-
-  describe 'checking for session existence' do
-    let(:session_id) { 'foo' }
-
-    before do
-      allow(store).to receive(:current_session_id)
-        .with(:env).and_return(session_id)
-    end
-
-    context 'when session id is not provided' do
-      context 'when session id is nil' do
-        let(:session_id) { nil }
-
-        it 'returns false' do
-          expect(store.send(:session_exists?, :env)).to eq(false)
-        end
-      end
-
-      context 'when session id is empty string' do
-        let(:session_id) { '' }
-
-        it 'returns false' do
-          allow(store).to receive(:current_session_id).with(:env).and_return('')
-          expect(store.send(:session_exists?, :env)).to eq(false)
-        end
-      end
-    end
-
-    context 'when session id is provided' do
-      let(:redis) do
-        double('redis').tap do |o|
-          allow(store).to receive(:single_redis).and_return(o)
-        end
-      end
-
-      context 'when session id does not exist in redis' do
-        it 'returns false' do
-          expect(redis).to receive(:exists).with('foo').and_return(false)
-          expect(store.send(:session_exists?, :env)).to eq(false)
-        end
-      end
-
-      context 'when session id exists in redis' do
-        it 'returns true' do
-          expect(redis).to receive(:exists).with('foo').and_return(true)
-          expect(store.send(:session_exists?, :env)).to eq(true)
-        end
-      end
-
-      context 'when redis is down' do
-        it 'returns true (fallback to old behavior)' do
-          allow(store).to receive(:with_redis).and_raise(Redis::CannotConnectError)
-          expect(store.send(:session_exists?, :env)).to eq(true)
-        end
-      end
-    end
-  end
-
   describe 'fetching a session' do
     let :options do
       {
@@ -298,7 +177,7 @@ describe RedisSessionStore do
       }
     end
 
-    let(:fake_key) { 'thisisarediskey' }
+    let(:fake_key) { Rack::Session::SessionId.new('thisisarediskey') }
 
     describe 'generate_sid' do
       it 'generates a secure ID' do
@@ -311,9 +190,11 @@ describe RedisSessionStore do
       redis = double('redis')
       allow(store).to receive(:single_redis).and_return(redis)
       allow(store).to receive(:generate_sid).and_return(fake_key)
-      expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key}")
+      expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key.private_id}").and_return(
+        Marshal.dump(''),
+      )
 
-      store.send(:get_session, double('env'), fake_key)
+      store.send(:find_session, double('env'), fake_key)
     end
 
     context 'when redis is down' do
@@ -322,22 +203,12 @@ describe RedisSessionStore do
         allow(store).to receive(:generate_sid).and_return('foop')
       end
 
-      it 'returns an empty session hash' do
-        expect(store.send(:get_session, double('env'), fake_key).last)
-          .to eq({})
-      end
-
-      it 'returns a newly generated sid' do
-        expect(store.send(:get_session, double('env'), fake_key).first)
-          .to eq('foop')
-      end
-
       context 'when :on_redis_down re-raises' do
         before { store.on_redis_down = ->(e, *) { raise e } }
 
         it 'explodes' do
           expect do
-            store.send(:get_session, double('env'), fake_key)
+            store.send(:find_session, double('env'), fake_key)
           end.to raise_error(Redis::CannotConnectError)
         end
       end
@@ -348,7 +219,7 @@ describe RedisSessionStore do
     context 'when the key is in the cookie hash' do
       let(:env) { { 'rack.request.cookie_hash' => cookie_hash } }
       let(:cookie_hash) { double('cookie hash') }
-      let(:fake_key) { 'thisisarediskey' }
+      let(:fake_key) { Rack::Session::SessionId.new('thisisarediskey') }
 
       before do
         allow(cookie_hash).to receive(:[]).and_return(fake_key)
@@ -358,9 +229,9 @@ describe RedisSessionStore do
         redis = double('redis')
         allow(store).to receive(:single_redis).and_return(redis)
         expect(redis).to receive(:del)
-          .with("#{options[:key_prefix]}#{fake_key}")
+          .with(fake_key.private_id)
 
-        store.send(:destroy, env)
+        store.send(:delete_session, env, fake_key, { drop: true })
       end
 
       context 'when redis is down' do
@@ -368,16 +239,12 @@ describe RedisSessionStore do
           allow(store).to receive(:single_redis).and_raise(Redis::CannotConnectError)
         end
 
-        it 'returns false' do
-          expect(store.send(:destroy, env)).to eq(false)
-        end
-
         context 'when :on_redis_down re-raises' do
           before { store.on_redis_down = ->(e, *) { raise e } }
 
           it 'explodes' do
             expect do
-              store.send(:destroy, env)
+              store.send(:delete_session, env, fake_key, {})
             end.to raise_error(Redis::CannotConnectError)
           end
         end
@@ -389,16 +256,16 @@ describe RedisSessionStore do
         redis = double('redis', setnx: true)
         allow(store).to receive(:single_redis).and_return(redis)
         sid = store.send(:generate_sid)
-        expect(redis).to receive(:del).with("#{options[:key_prefix]}#{sid}")
+        expect(redis).to receive(:del).with("#{options[:key_prefix]}#{sid.private_id}")
 
-        store.send(:destroy_session, {}, sid, nil)
+        store.send(:delete_session, {}, sid, { drop: true })
       end
     end
   end
 
   describe 'session encoding' do
     let(:env)          { double('env') }
-    let(:session_id)   { 12_345 }
+    let(:session_id)   { Rack::Session::SessionId.new('thisisarediskey') }
     let(:session_data) { { 'some' => 'data' } }
     let(:options)      { {} }
     let(:encoded_data) { Marshal.dump(session_data) }
@@ -411,12 +278,12 @@ describe RedisSessionStore do
 
     shared_examples_for 'serializer' do
       it 'encodes correctly' do
-        expect(redis).to receive(:set).with('12345', expected_encoding)
-        store.send(:set_session, env, session_id, session_data, options)
+        expect(redis).to receive(:set).with(session_id.private_id, expected_encoding, { ex: nil })
+        store.send(:write_session, env, session_id, session_data, options)
       end
 
       it 'decodes correctly' do
-        expect(store.send(:get_session, env, session_id))
+        expect(store.send(:find_session, env, session_id))
           .to eq([session_id, session_data])
       end
     end
@@ -432,21 +299,6 @@ describe RedisSessionStore do
       let(:encoded_data) { '{"some":"data"}' }
 
       it_behaves_like 'serializer'
-    end
-
-    context 'hybrid' do
-      let(:options) { { serializer: :hybrid } }
-      let(:expected_encoding) { '{"some":"data"}' }
-
-      context 'marshal encoded data' do
-        it_behaves_like 'serializer'
-      end
-
-      context 'json encoded data' do
-        let(:encoded_data) { '{"some":"data"}' }
-
-        it_behaves_like 'serializer'
-      end
     end
 
     context 'custom' do
@@ -470,22 +322,25 @@ describe RedisSessionStore do
   end
 
   describe 'handling decode errors' do
+    let(:fake_key) { Rack::Session::SessionId.new('thisisarediskey') }
+    let(:fake_redis) { double('redis',
+                             get: "\x04\bo:\nNonExistentClass\x00",
+                             set: true,
+                             del: true) }
     context 'when a class is serialized that does not exist' do
       before do
         allow(store).to receive(:single_redis)
-          .and_return(double('redis',
-                             get: "\x04\bo:\nNonExistentClass\x00",
-                             del: true))
+          .and_return(fake_redis)
       end
 
       it 'returns an empty session' do
-        expect(store.send(:load_session_from_redis, 'whatever')).to be_nil
+        expect(store.send(:find_session, double('env'), fake_key).last).to eq({})
       end
 
       it 'destroys and drops the session' do
-        expect(store).to receive(:destroy_session_from_sid)
-          .with('wut', drop: true)
-        store.send(:load_session_from_redis, 'wut')
+        expect(store).to receive(:delete_session_from_redis)
+          .with(fake_redis, fake_key, { drop: true })
+        store.send(:find_session, double('env'), fake_key)
       end
 
       context 'when a custom on_session_load_error handler is provided' do
@@ -497,27 +352,31 @@ describe RedisSessionStore do
         end
 
         it 'passes the error and the sid to the handler' do
-          store.send(:load_session_from_redis, 'foo')
+          store.send(:find_session, double('env'), fake_key)
           expect(@e).to be_kind_of(StandardError)
-          expect(@sid).to eq('foo')
+          expect(@sid).to eq(fake_key)
         end
       end
     end
 
     context 'when the encoded data is invalid' do
+      let(:fake_redis) { double('redis',
+                             get: "\x00\x00\x00\x00",
+                             set: true,
+                             del: true) }
       before do
         allow(store).to receive(:single_redis)
-          .and_return(double('redis', get: "\x00\x00\x00\x00", del: true))
+          .and_return(fake_redis)
       end
 
       it 'returns an empty session' do
-        expect(store.send(:load_session_from_redis, 'bar')).to be_nil
+        expect(store.send(:find_session, double('env'), fake_key).last).to eq({})
       end
 
       it 'destroys and drops the session' do
-        expect(store).to receive(:destroy_session_from_sid)
-          .with('wut', drop: true)
-        store.send(:load_session_from_redis, 'wut')
+        expect(store).to receive(:delete_session_from_redis)
+          .with(fake_redis, fake_key, { drop: true })
+        store.send(:find_session, double('env'), fake_key)
       end
 
       context 'when a custom on_session_load_error handler is provided' do
@@ -529,9 +388,9 @@ describe RedisSessionStore do
         end
 
         it 'passes the error and the sid to the handler' do
-          store.send(:load_session_from_redis, 'foo')
+          store.send(:find_session, double('env'), fake_key)
           expect(@e).to be_kind_of(StandardError)
-          expect(@sid).to eq('foo')
+          expect(@sid).to eq(fake_key)
         end
       end
     end
@@ -566,25 +425,25 @@ describe RedisSessionStore do
   describe 'setting the session' do
     it 'allows changing the session' do
       env = { 'rack.session.options' => {} }
-      sid = 1234
+      sid = Rack::Session::SessionId.new('thisisarediskey')
       allow(store).to receive(:single_redis).and_return(Redis.new)
       data1 = { 'foo' => 'bar' }
-      store.send(:set_session, env, sid, data1)
+      store.send(:write_session, env, sid, data1, {})
       data2 = { 'baz' => 'wat' }
-      store.send(:set_session, env, sid, data2)
-      _, session = store.send(:get_session, env, sid)
+      store.send(:write_session, env, sid, data2, {})
+      _, session = store.send(:find_session, env, sid)
       expect(session).to eq(data2)
     end
 
     it 'allows changing the session when the session has an expiry' do
       env = { 'rack.session.options' => { expire_after: 60 } }
-      sid = 1234
+      sid = Rack::Session::SessionId.new('thisisarediskey')
       allow(store).to receive(:single_redis).and_return(Redis.new)
       data1 = { 'foo' => 'bar' }
-      store.send(:set_session, env, sid, data1)
+      store.send(:write_session, env, sid, data1, {})
       data2 = { 'baz' => 'wat' }
-      store.send(:set_session, env, sid, data2)
-      _, session = store.send(:get_session, env, sid)
+      store.send(:write_session, env, sid, data2, {})
+      _, session = store.send(:find_session, env, sid)
       expect(session).to eq(data2)
     end
   end


### PR DESCRIPTION
Highlights:

- Removes the `session_exists?` override which sends a Redis `exists` command on every request
  - The `exists` check is I think unnecessary and we can save a bit of Redis load
- Allows migrating to the newer public/private id to more completely address https://github.com/advisories/GHSA-hrqr-hxpp-chr3
  - I don't think https://github.com/roidrage/redis-session-store/pull/125 was sufficient to address the vulnerability since the internal `private_id` was never used
- Uses `nx: true` when writing new sessions to avoid a very rare race condition where the same ID is generated for two different sessions
- Consolidates Redis network errors into one method

These changes were inspired and guided by https://github.com/petergoldstein/dalli/blob/88614e8/lib/rack/session/dalli.rb and https://github.com/rack/rack-session/blob/c9beee6/lib/rack/session/pool.rb

## Benchmarks

<details>
<summary>No Session</summary>

```
❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️

[863a934807] (1.2318 seconds) "new session" ref: "863a934807080705b323ea6be19b28f061953781"
  FASTER 🚀🚀🚀 by:
    1.0351x [older/newer]
    3.3903% [(older - newer) / older * 100]
[a0624a25c1] (1.2751 seconds) "old session" ref: "a0624a25c137df326a47a610d1e9fa0c68885eb8"

Iterations per sample: 200
Samples: 175

Test type: Kolmogorov Smirnov
Confidence level: 99.0 %
Is significant? (max > critical): true
D critical: 0.1622197836444317
D max: 0.30857142857142855

Histograms (time ranges are in seconds):

   [863a934807] description:                                 [a0624a25c1] description:
     "new session"                                              "old session"
              ┌                                        ┐                ┌                                        ┐
   [1.0, 1.1) ┤ 0                                            [1.0, 1.1) ┤ 0
   [1.1, 1.2) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 93       [1.1, 1.2) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 56
   [1.3, 1.4) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 60                    [1.3, 1.4) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 90
   [1.4, 1.5) ┤▇▇▇▇▇▇▇▇▇ 22                                  [1.4, 1.5) ┤▇▇▇▇▇▇▇▇▇ 22
   [1.5, 1.6) ┤ 0                                            [1.5, 1.6) ┤▇▇ 4
   [1.6, 1.7) ┤ 0                                            [1.6, 1.7) ┤▇ 2
   [1.8, 1.9) ┤ 0                                            [1.8, 1.9) ┤ 0
   [1.9, 2.0) ┤ 0                                            [1.9, 2.0) ┤ 0
   [2.0, 2.1) ┤ 0                                            [2.0, 2.1) ┤ 0
   [2.1, 2.2) ┤ 0                                            [2.1, 2.2) ┤ 0
   [2.3, 2.4) ┤ 0                                            [2.3, 2.4) ┤ 1
              └                                        ┘                └                                        ┘
                         # of runs in range                                        # of runs in range
```

</details>

<details>
<summary>Existing Session</summary>

```
❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️

[863a934807] (1.2322 seconds) "new session" ref: "863a934807080705b323ea6be19b28f061953781"
  FASTER 🚀🚀🚀 by:
    1.0676x [older/newer]
    6.3350% [(older - newer) / older * 100]
[a0624a25c1] (1.3155 seconds) "old session" ref: "a0624a25c137df326a47a610d1e9fa0c68885eb8"

Iterations per sample: 200
Samples: 59

Test type: Kolmogorov Smirnov
Confidence level: 99.0 %
Is significant? (max > critical): true
D critical: 0.2793809799644561
D max: 0.5423728813559322

Histograms (time ranges are in seconds):

   [863a934807] description:                                 [a0624a25c1] description:
     "new session"                                              "old session"
              ┌                                        ┐                ┌                                        ┐
   [1.0, 1.1) ┤ 0                                            [1.0, 1.1) ┤ 0
   [1.1, 1.2) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 33       [1.1, 1.2) ┤▇▇▇▇▇▇▇ 8
   [1.3, 1.4) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 19                      [1.3, 1.4) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 42
   [1.4, 1.5) ┤▇▇▇▇ 4                                        [1.4, 1.5) ┤▇▇▇▇▇ 6
   [1.5, 1.6) ┤▇ 1                                           [1.5, 1.6) ┤▇▇▇ 3
   [1.6, 1.7) ┤▇ 1                                           [1.6, 1.7) ┤ 0
   [1.8, 1.9) ┤ 0                                            [1.8, 1.9) ┤ 0
   [1.9, 2.0) ┤▇ 1                                           [1.9, 2.0) ┤ 0
              └                                        ┘                └                                        ┘
                         # of runs in range                                        # of runs in range
```

</summary>