### PR TITLE
Fix key migration process

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ In your Rails app, throw in an initializer with the following contents:
 ``` ruby
 Rails.application.config.session_store :redis_session_store,
   key: 'your_session_key',
+  expire_after: nil,  # cookie expiration
   redis: {
-    expire_after: 120.minutes,  # cookie expiration
-    ttl: 120.minutes,           # Redis expiration, defaults to 'expire_after'
+    ttl: 120.minutes,           # Redis expiration
     key_prefix: 'myapp:session:',
     url: 'redis://localhost:6379/0',
   }

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Rails.application.config.session_store :redis_session_store,
 By default the Marshal serializer is used. With Rails 4, you can use JSON as a
 custom serializer:
 
-* `:marsha` - serialize cookie values with `Marshal` (Default)
+* `:marshal` - serialize cookie values with `Marshal` (Default)
 * `:json` - serialize cookie values with `JSON`
 * `CustomClass` - You can just pass the constant name of a class that responds to `.load` and `.dump`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a forked version of the [redis-session-store](https://github.com/roidrag
 ## Installation
 
 ``` ruby
-gem 'redis-session-store', git: 'https://github.com/18F/redis-session-store.git', tag: 'v1.0.0-18f'
+gem 'redis-session-store', git: 'https://github.com/18F/redis-session-store.git', tag: 'v1.0.1-18f'
 ```
 
 ## Migrating from Rack::Session::SessionId#public_id to Rack::Session::SessionId#private_id

--- a/README.md
+++ b/README.md
@@ -24,52 +24,52 @@ Rails.application.config.session_store :redis_session_store,
   # ...
   redis: {
    # ...
-   read_fallback: true,
-   write_fallback: true,
-   read_primary: false,
-   write_primary: false,
+   read_public_id: true,
+   write_public_id: true,
+   read_private_id: false,
+   write_private_id: false,
   }
 ```
 
-2. Enabling writing to the primary key
+2. Enabling writing to the private\_id key
 
 ```ruby
 Rails.application.config.session_store :redis_session_store,
   # ...
   redis: {
    # ...
-   read_fallback: true,
-   write_fallback: true,
-   read_primary: false,
-   write_primary: true,
+   read_public_id: true,
+   write_public_id: true,
+   read_private_id: false,
+   write_private_id: true,
   }
 ```
 
-3. Enabling reading the primary key
+3. Enabling reading the private\_id key and disabling reading the public\_id key
 
 ```ruby
 Rails.application.config.session_store :redis_session_store,
   # ...
   redis: {
    # ...
-   read_fallback: true,
-   write_fallback: true,
-   read_primary: true,
-   write_primary: true,
+   read_public_id: false,
+   write_public_id: true,
+   read_private_id: true,
+   write_private_id: true,
   }
 ```
 
-4. Disabling reading and writing for the fallback key
+4. Disabling writing for the public\_id key
 
 ```ruby
 Rails.application.config.session_store :redis_session_store,
   # ...
   redis: {
    # ...
-   read_fallback: false,
-   write_fallback: false,
-   read_primary: true,
-   write_primary: true,
+   read_public_id: false,
+   write_public_id: false,
+   read_private_id: true,
+   write_private_id: true,
   }
 ```
 

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -5,7 +5,7 @@ require 'redis'
 # Redis session storage for Rails, and for Rails only. Derived from
 # the MemCacheStore code, simply dropping in Redis instead.
 class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
-  VERSION = '1.0.0-18f'.freeze
+  VERSION = '1.0.1-18f'.freeze
 
   # ==== Options
   # * +:key+ - Same as with the other cookie stores, key name

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -13,7 +13,6 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
   #   * +:url+ - Redis url, default is redis://localhost:6379/0
   #   * +:key_prefix+ - Prefix for keys used in Redis, e.g. +myapp:+
   #   * +:ttl+ - Default Redis TTL for sessions
-  #   * +:expire_after+ - A number in seconds for session timeout
   #   * +:client+ - Connect to Redis with given object rather than create one
   #   * +:client_pool:+ - Connect to Redis with a ConnectionPool
   # * +:on_redis_down:+ - Called with err, env, and SID on Errno::ECONNREFUSED
@@ -25,7 +24,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
   #     Rails.application.config.session_store :redis_session_store,
   #       key: 'your_session_key',
   #       redis: {
-  #         expire_after: 120.minutes,
+  #         ttl: 120.minutes,
   #         key_prefix: 'myapp:session:',
   #         url: 'redis://localhost:6379/0'
   #       },

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -32,7 +32,6 @@ describe RedisSessionStore do
           port: 16_379,
           db: 2,
           key_prefix: 'myapp:session:',
-          expire_after: 60 * 120
         }
       }
     end
@@ -57,10 +56,6 @@ describe RedisSessionStore do
       expect(default_options[:key_prefix]).to eq('myapp:session:')
     end
 
-    it 'assigns the :expire_after option to @default_options' do
-      expect(default_options[:expire_after]).to eq(60 * 120)
-    end
-
     context 'with a :client_pool' do
       let :options do
         {
@@ -79,7 +74,7 @@ describe RedisSessionStore do
     end
   end
 
-  describe 'when configured with both :ttl and :expire_after' do
+  describe 'when configured with :ttl' do
     let(:ttl_seconds) { 60 * 120 }
     let :options do
       {
@@ -91,14 +86,12 @@ describe RedisSessionStore do
           db: 2,
           key_prefix: 'myapp:session:',
           ttl: ttl_seconds,
-          expire_after: nil
         }
       }
     end
 
     it 'assigns the :ttl option to @default_options' do
       expect(default_options[:ttl]).to eq(ttl_seconds)
-      expect(default_options[:expire_after]).to be_nil
     end
   end
 
@@ -111,7 +104,6 @@ describe RedisSessionStore do
         port: 26_379,
         db: 4,
         key_prefix: 'appydoo:session:',
-        expire_after: 60 * 60
       }
     end
 
@@ -134,10 +126,6 @@ describe RedisSessionStore do
     it 'assigns the :key_prefix option to @default_options' do
       expect(default_options[:key_prefix]).to eq('appydoo:session:')
     end
-
-    it 'assigns the :expire_after option to @default_options' do
-      expect(default_options[:expire_after]).to eq(60 * 60)
-    end
   end
 
   describe 'when initializing with existing redis object' do
@@ -148,7 +136,7 @@ describe RedisSessionStore do
         redis: {
           client: redis_client,
           key_prefix: 'myapp:session:',
-          expire_after: 60 * 30
+          ttl: 60,
         }
       }
     end
@@ -167,8 +155,8 @@ describe RedisSessionStore do
       expect(default_options[:key_prefix]).to eq('myapp:session:')
     end
 
-    it 'assigns the :expire_after option to @default_options' do
-      expect(default_options[:expire_after]).to eq(60 * 30)
+    it 'assigns the :ttl option to @default_options' do
+      expect(default_options[:ttl]).to eq(60)
     end
   end
 
@@ -214,19 +202,6 @@ describe RedisSessionStore do
       store.send(:find_session, ActionDispatch::TestRequest.create, fake_key)
     end
 
-    it 'retrieves the prefixed public_id key from redis when read_public_id is not enabled' do
-      options[:redis] = { write_private_id: true, write_public_id: true, read_private_id: true, read_public_id: false }
-      store = described_class.new(nil, options)
-      redis = double('redis')
-      allow(store).to receive(:single_redis).and_return(redis)
-      allow(store).to receive(:generate_sid).and_return(fake_key)
-      expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key.private_id}").and_return(
-        Marshal.dump(''),
-      )
-
-      store.send(:find_session, ActionDispatch::TestRequest.create, fake_key)
-    end
-
     it 'retrieves the prefixed public_id from redis when read_public_id is enabled and the private_id does not exist' do
       options[:redis] = { read_private_id: true, read_public_id: true }
       store = described_class.new(nil, options)
@@ -236,6 +211,32 @@ describe RedisSessionStore do
       expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key.private_id}").and_return(
         nil
       )
+      expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key.public_id}").and_return(
+        Marshal.dump('')
+      )
+
+      store.send(:find_session, ActionDispatch::TestRequest.create, fake_key)
+    end
+
+    it 'retrieves the prefixed public_id from redis when read_public_id is enabled and read_private_id is not enabled' do
+      options[:redis] = { read_private_id: false, read_public_id: true }
+      store = described_class.new(nil, options)
+      redis = double('redis')
+      allow(store).to receive(:single_redis).and_return(redis)
+      allow(store).to receive(:generate_sid).and_return(fake_key)
+      expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key.public_id}").and_return(
+        Marshal.dump('')
+      )
+
+      store.send(:find_session, ActionDispatch::TestRequest.create, fake_key)
+    end
+
+    it 'retrieves the prefixed public_id from redis when read_public_id is enabled and read_private_id is not enabled' do
+      options[:redis] = { read_private_id: false, read_public_id: true }
+      store = described_class.new(nil, options)
+      redis = double('redis')
+      allow(store).to receive(:single_redis).and_return(redis)
+      allow(store).to receive(:generate_sid).and_return(fake_key)
       expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key.public_id}").and_return(
         Marshal.dump('')
       )
@@ -471,17 +472,33 @@ describe RedisSessionStore do
       expect(session).to eq(data2)
     end
 
-    it 'allows changing the session when the session has an expiry' do
-      env = { 'rack.session.options' => { expire_after: 60 } }
-      req = ActionDispatch::TestRequest.create(env)
+    it 'sets EX option when Redis TTL is configured' do
+      store = described_class.new(nil, { redis: { ttl: 60 } })
+      req = ActionDispatch::TestRequest.create({})
       sid = Rack::Session::SessionId.new('thisisarediskey')
-      allow(store).to receive(:single_redis).and_return(Redis.new)
-      data1 = { 'foo' => 'bar' }
-      store.send(:write_session, req, sid, data1, {})
-      data2 = { 'baz' => 'wat' }
-      store.send(:write_session, req, sid, data2, {})
-      _, session = store.send(:find_session, req, sid)
-      expect(session).to eq(data2)
+      redis = double('redis')
+      allow(store).to receive(:single_redis).and_return(redis)
+      expect(redis).to receive(:set).with("#{options[:key_prefix]}#{sid.private_id}", instance_of(String), { ex: 60 })
+      store.send(:write_session, req, sid, { a: 1 }, {})
+    end
+
+    it 'sets EX and NX options when Redis TTL is configured and new session is being set' do
+      store = described_class.new(nil, { redis: { ttl: 60 } })
+      req = ActionDispatch::TestRequest.create({ 'redis_session_store.new_session' => true })
+      sid = Rack::Session::SessionId.new('thisisarediskey')
+      redis = double('redis')
+      allow(store).to receive(:single_redis).and_return(redis)
+      expect(redis).to receive(:set).with("#{options[:key_prefix]}#{sid.private_id}", instance_of(String), { ex: 60, nx: true })
+      store.send(:write_session, req, sid, { a: 1 }, {})
+    end
+
+    it 'sets NX option when new session is being set' do
+      req = ActionDispatch::TestRequest.create({ 'redis_session_store.new_session' => true })
+      sid = Rack::Session::SessionId.new('thisisarediskey')
+      redis = double('redis')
+      allow(store).to receive(:single_redis).and_return(redis)
+      expect(redis).to receive(:set).with("#{options[:key_prefix]}#{sid.private_id}", instance_of(String), { nx: true })
+      store.send(:write_session, req, sid, { a: 1 }, {})
     end
 
     it 'writes to private_id and public_id if write_private_id and write_public_id are enabled' do

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -188,19 +188,8 @@ describe RedisSessionStore do
       end
     end
 
-    it 'retrieves the prefixed private_id key from redis when read_fallback is not enabled' do
-      redis = double('redis')
-      allow(store).to receive(:single_redis).and_return(redis)
-      allow(store).to receive(:generate_sid).and_return(fake_key)
-      expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key.private_id}").and_return(
-        Marshal.dump(''),
-      )
-
-      store.send(:find_session, ActionDispatch::TestRequest.create, fake_key)
-    end
-
-    it 'retrieves the prefixed private_id key from redis when read_fallback is not enabled' do
-      options[:redis] = { write_fallback: true }
+    it 'retrieves the prefixed primary key from redis when read_fallback is not enabled' do
+      options[:redis] = { write_primary: true, write_fallback: false, read_primary: true, read_fallback: false }
       store = described_class.new(nil, options)
       redis = double('redis')
       allow(store).to receive(:single_redis).and_return(redis)
@@ -212,8 +201,34 @@ describe RedisSessionStore do
       store.send(:find_session, ActionDispatch::TestRequest.create, fake_key)
     end
 
-    it 'retrieves the prefixed public_id key from redis when read_fallback is enabled and the private_id key does not exist' do
-      options[:redis] = { read_fallback: true }
+    it 'does not retrieve the prefixed fallback key from redis when read_fallback is not enabled' do
+      options[:redis] = { write_primary: true, write_fallback: false, read_primary: true, read_fallback: false }
+      store = described_class.new(nil, options)
+      redis = double('redis')
+      allow(store).to receive(:single_redis).and_return(redis)
+      allow(store).to receive(:generate_sid).and_return(fake_key)
+      expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key.private_id}").and_return(
+        Marshal.dump(''),
+      )
+
+      store.send(:find_session, ActionDispatch::TestRequest.create, fake_key)
+    end
+
+    it 'retrieves the prefixed public_id key from redis when read_fallback is not enabled' do
+      options[:redis] = { write_primary: true, write_fallback: true, read_primary: true, read_fallback: false }
+      store = described_class.new(nil, options)
+      redis = double('redis')
+      allow(store).to receive(:single_redis).and_return(redis)
+      allow(store).to receive(:generate_sid).and_return(fake_key)
+      expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key.private_id}").and_return(
+        Marshal.dump(''),
+      )
+
+      store.send(:find_session, ActionDispatch::TestRequest.create, fake_key)
+    end
+
+    it 'retrieves the prefixed fallback key from redis when read_fallback is enabled and the primary key does not exist' do
+      options[:redis] = { read_primary: true, read_fallback: true }
       store = described_class.new(nil, options)
       redis = double('redis')
       allow(store).to receive(:single_redis).and_return(redis)
@@ -248,7 +263,7 @@ describe RedisSessionStore do
 
   describe 'destroying a session' do
     context 'when destroyed via #destroy_session' do
-      it 'deletes the prefixed private_id key from redis when write_fallback is not enabled' do
+      it 'deletes the prefixed primary key from redis when write_fallback is not enabled' do
         redis = double('redis')
         allow(store).to receive(:single_redis).and_return(redis)
         sid = store.send(:generate_sid)
@@ -257,8 +272,19 @@ describe RedisSessionStore do
         store.send(:delete_session, {}, sid, { drop: true })
       end
 
-      it 'deletes the prefixed private_id and public_id keys from redis when write_fallback is enabled' do
+      it 'deletes the prefixed primary and fallback keys from redis when write_fallback is enabled' do
         store = described_class.new(nil, { redis: { write_fallback: true } })
+        redis = double('redis')
+        allow(store).to receive(:single_redis).and_return(redis)
+        sid = store.send(:generate_sid)
+        expect(redis).to receive(:del).with("#{options[:key_prefix]}#{sid.private_id}")
+        expect(redis).to receive(:del).with("#{options[:key_prefix]}#{sid.public_id}")
+
+        store.send(:delete_session, {}, sid, { drop: true })
+      end
+
+      it 'deletes the prefixed primary and fallback keys from redis when read_fallback is enabled' do
+        store = described_class.new(nil, { redis: { read_fallback: true } })
         redis = double('redis')
         allow(store).to receive(:single_redis).and_return(redis)
         sid = store.send(:generate_sid)
@@ -458,25 +484,39 @@ describe RedisSessionStore do
       expect(session).to eq(data2)
     end
 
-    it 'writes to public_id if write_fallback is enabled' do
-      store = described_class.new(nil, { redis: { write_fallback: true } })
+    it 'writes to primary and fallback key if write_primary and write_fallback are enabled' do
+      store = described_class.new(nil, { redis: { write_primary: true, write_fallback: true } })
       redis = double('redis')
       req = ActionDispatch::TestRequest.create({})
       sid = Rack::Session::SessionId.new('thisisarediskey')
       allow(store).to receive(:single_redis).and_return(redis)
       data1 = { 'foo' => 'bar' }
       expect(redis).to receive(:set).with("#{options[:key_prefix]}#{sid.public_id}", instance_of(String))
+      expect(redis).to receive(:set).with("#{options[:key_prefix]}#{sid.private_id}", instance_of(String))
 
       store.send(:write_session, req, sid, data1, {})
     end
 
-    it 'writes to private_id if write_fallback is not enabled' do
+    it 'writes to primary key if write_primary is enabled' do
+      store = described_class.new(nil, { redis: { write_primary: true } })
       redis = double('redis')
       req = ActionDispatch::TestRequest.create({})
       sid = Rack::Session::SessionId.new('thisisarediskey')
       allow(store).to receive(:single_redis).and_return(redis)
       data1 = { 'foo' => 'bar' }
       expect(redis).to receive(:set).with("#{options[:key_prefix]}#{sid.private_id}", instance_of(String))
+
+      store.send(:write_session, req, sid, data1, {})
+    end
+
+    it 'writes only to fallback key if write_fallback is enabled and write_primary is not enabled' do
+      store = described_class.new(nil, { redis: { write_primary: false, write_fallback: true } })
+      redis = double('redis')
+      req = ActionDispatch::TestRequest.create({})
+      sid = Rack::Session::SessionId.new('thisisarediskey')
+      allow(store).to receive(:single_redis).and_return(redis)
+      data1 = { 'foo' => 'bar' }
+      expect(redis).to receive(:set).with("#{options[:key_prefix]}#{sid.public_id}", instance_of(String))
 
       store.send(:write_session, req, sid, data1, {})
     end


### PR DESCRIPTION
While testing https://github.com/18F/identity-idp/pull/8253, I found an issue where it's possible to receive an inconsistent read from a fallback key because there's no stage where we write to both keys. To ensure the migration is compatible with zero-downtime, I've added a couple more configuration keys. I've also updated the README to document the migration process as well as our differences from the upstream repository.
