### PR TITLE
Allow actionpack 8.x

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -5,7 +5,7 @@ require 'redis'
 # Redis session storage for Rails, and for Rails only. Derived from
 # the MemCacheStore code, simply dropping in Redis instead.
 class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
-  VERSION = '1.0.1-18f'.freeze
+  VERSION = '1.0.2-18f'.freeze
 
   # ==== Options
   # * +:key+ - Same as with the other cookie stores, key name

--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version = File.read('lib/redis-session-store.rb')
                     .match(/^  VERSION = '(.*)'/)[1]
 
-  gem.add_runtime_dependency 'actionpack', '>= 6', '< 8'
+  gem.add_runtime_dependency 'actionpack', '>= 6', '< 9'
   gem.add_runtime_dependency 'redis', '>= 4.3', '< 6'
 
   gem.add_development_dependency 'connection_pool', '~> 2'


### PR DESCRIPTION
With the release of [Rails 8](https://guides.rubyonrails.org/8_0_release_notes.html) and associated libraries, we can expand the versions allowed since `actionpack` doesn't appear to have any breaking changes that would affect us.